### PR TITLE
V2.1.1 FoodFix

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -12,7 +12,7 @@ namespace KitchenCountUp
     {
         public const string MOD_GUID = "Swift.PlateUp.CountUp";
         public const string MOD_NAME = "CountUp!";
-        public const string MOD_VERSION = "2.1.0";
+        public const string MOD_VERSION = "2.1.1";
         public const string MOD_AUTHOR = "Swift, Nova & Penthilus";
         public const string MOD_GAMEVERSION = ">=1.3.0";
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]

--- a/Views/ItemIconView.cs
+++ b/Views/ItemIconView.cs
@@ -35,7 +35,7 @@ namespace KitchenCountUp.Views
         {
             ProcessIcons.gameObject.transform.localPosition = Vector3.up * 0.8f;
             string iconSet = Mod.ItemSplitPreference.Get() && Data.Count > 0 && Data.Count < 300 ? $"{Item.GetIconSet(item)}<cspace=-35>{Data.Count}</cspace>" : Item.GetIconSet(item);
-            ProcessIcons.text = !Data.IsPartial ? iconSet : "";
+            ProcessIcons.text = iconSet;
         }
 
         private void UpdateForProcess(ViewData Data, Item item)

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -1,6 +1,6 @@
 # CountUp! Multiplayer Testing Guide
 
-This guide is for testers verifying the multiplayer synchronization of the CountUp! v2.1.0 update.
+This guide is for testers verifying the multiplayer synchronization of the CountUp! v2.1.1 update.
 
 ## Test Setup
 1. **Host** installs the new `CountUp.dll`.
@@ -33,7 +33,7 @@ This guide is for testers verifying the multiplayer synchronization of the Count
 
 *Note: The mod now uses a centralized identity-based host check (`NetworkingUtils.IsHost()`) and the `Kitchen` namespace for custom components. This ensures that host-sent data is natively synchronized to all clients via PlateUp's engine.*
 
-## File Manifest (v2.1.0)
+## File Manifest (v2.1.1)
 ### Modified
 - `Mod.cs`
 - `CountUp.csproj`


### PR DESCRIPTION
Fixes issue with some portion-able foods where an `IsPartial` check was preventing the counters from showing; local only confirmation. 