### PR TITLE
Fix: Clear portionable item icon when empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # CountUp!
+
 Displays a number above certain foods to indicate how many portions are left for serving. Works for Base game foods & modded ones.
 
 ### Requirements
+
 - **KitchenLib**: Required for mod loading and base functionality.
 - **PreferenceSystem**: Required for the options menu.
 - **PlatePatch**: **Highly Recommended / Required for Multiplayer**. Fixes native PlateUp networking to allow modded components (like counters) to sync to clients.
@@ -9,9 +11,11 @@ Displays a number above certain foods to indicate how many portions are left for
 ---
 
 ### Technical Details (For Modders)
+
 As of PlateUp! 1.3.0, the game shifted to strict AOT (Ahead-of-Time) compilation and native Networking to support cross-platform play.
 
 This mod has been updated to use the new native ECS multiplayer architecture:
+
 - Custom data is synchronized via `IModComponent` structs (`CCountUpAppliance` and `CCountUpItem`).
 - These components are placed in the `Kitchen` namespace and use `[MessagePackObject]` attributes so the networking engine recognizes and synchronizes them to all clients.
 - Host Identity logic is managed by `NetworkingUtils.IsHost()` which utilizes snapshots of the network peer list. This ensures that only the host populates shared components.

--- a/Systems/ItemCountSyncSystem.cs
+++ b/Systems/ItemCountSyncSystem.cs
@@ -17,7 +17,7 @@ namespace KitchenCountUp.Systems
         protected override void Initialise()
         {
             base.Initialise();
-            query = GetEntityQuery(new QueryHelper().All(typeof(CItem), typeof(CLinkedView)).Any(typeof(CSplittableItem), typeof(CItemUndergoingProcess)));
+            query = GetEntityQuery(new QueryHelper().All(typeof(CItem), typeof(CLinkedView)).Any(typeof(CSplittableItem), typeof(CItemUndergoingProcess), typeof(CCountUpItem)));
         }
 
         protected override void OnUpdate()
@@ -28,12 +28,26 @@ namespace KitchenCountUp.Systems
             foreach (var entity in entities)
             {
                 Require<CItem>(entity, out var itemComp);
+                bool hasSplittable = Require<CSplittableItem>(entity, out var splittable);
+                bool undergoingProcess = Has<CItemUndergoingProcess>(entity);
+
+                if (!hasSplittable && !undergoingProcess)
+                {
+                    if (Require<CCountUpItem>(entity, out var countUp) && countUp.ItemID != 0)
+                    {
+                        Set(entity, new CCountUpItem
+                        {
+                            ItemID = 0,
+                            Count = 0,
+                            UndergoingProcess = false,
+                            IsPartial = false
+                        });
+                    }
+                    continue;
+                }
                 
                 if (!GameData.Main.TryGet<Item>(itemComp.ID, out var item))
                     continue;
-
-                bool hasSplittable = Require<CSplittableItem>(entity, out var splittable);
-                bool undergoingProcess = Has<CItemUndergoingProcess>(entity);
 
                 int splitAdditive = item.IsSplittable && item.SplitDepletedItems.Contains(item.SplitSubItem) ? 1 : 0;
                 int count = hasSplittable ? splittable.RemainingCount + splitAdditive : 0;

--- a/Views/ItemIconView.cs
+++ b/Views/ItemIconView.cs
@@ -18,8 +18,14 @@ namespace KitchenCountUp.Views
 
         protected override void UpdateData(ViewData Data)
         {
-            if (ProcessIcons == null || !GameData.Main.TryGet<Item>(Data.ItemID, out var item))
+            if (ProcessIcons == null)
                 return;
+
+            if (Data.ItemID == 0 || !GameData.Main.TryGet<Item>(Data.ItemID, out var item))
+            {
+                ProcessIcons.text = "";
+                return;
+            }
 
             if (Data.UndergoingProcess)
             {

--- a/docs/testing_guide.md
+++ b/docs/testing_guide.md
@@ -3,15 +3,17 @@
 This guide is for testers verifying the multiplayer synchronization of the CountUp! v2.1.1 update.
 
 ## Test Setup
+
 1. **Host** installs the new `CountUp.dll`.
 2. **Host & Client** should have **PlatePatch** installed to ensure multiplayer data synchronization.
 3. **Client** connects to the lobby.
-3. Verify that the Host has enabled the features in the **Options > Mod Preferences** (or Pause Menu) via the new `PreferenceSystem` UI.
+4. Verify that the Host has enabled the features in the **Options > Mod Preferences** (or Pause Menu) via the new `PreferenceSystem` UI.
    - *Count Bin Space*
    - *Count Provider Remaining*
    - *Count Item Splits*
 
 ## Scenario 1: Bins & Providers (ApplianceCountView)
+
 1. Load into the **Lobby/Headquarters**.
 2. Have the **Host** pull a **Plate** from the plate stack in the lobby. The counter over the remaining plates should hover.
 3. Have the **Client** verify they can see the exact same plate count hovering over the provider.
@@ -21,26 +23,32 @@ This guide is for testers verifying the multiplayer synchronization of the Count
 *Note: While some tests (like plates) work in the lobby, Day 1 of a new run is the best environment for a full verification of all counters.*
 
 ## Scenario 2: Splittables (ItemIconView)
+
 1. Create a **Pizza** or **Bread** (any splittable item).
 2. Cook the item and place it on a counter.
-3. Have the **Host** slice the item. 
+3. Have the **Host** slice the item.
 4. Verify the hovering counter correctly displays the number of slices remaining.
 5. Have the **Client** grab a slice. Verify that both the physical slices and the hovering counter decrease accurately.
+6. If the splittable leaves an empty container (such as a pot), verify that the counter does not display.
 
 ## Expected Behavior
+
 - **Success:** The Client sees the exact numbers the Host sees at all times, and they update in real-time.
 - **Failure:** The Client sees numbers that do not match the Host's values or seeing no numbers when the Host sees them.
 
 *Note: The mod now uses a centralized identity-based host check (`NetworkingUtils.IsHost()`) and the `Kitchen` namespace for custom components. This ensures that host-sent data is natively synchronized to all clients via PlateUp's engine.*
 
 ## File Manifest (v2.1.1)
+
 ### Modified
+
 - `Mod.cs`
 - `CountUp.csproj`
 - `Views/ApplianceCountView.cs`
 - `Views/ItemIconView.cs`
 
 ### Added
+
 - `Components/CCountUpData.cs`
 - `Systems/ApplianceCountSyncSystem.cs`
 - `Systems/ItemCountSyncSystem.cs`
@@ -48,4 +56,5 @@ This guide is for testers verifying the multiplayer synchronization of the Count
 - `docs/testing_guide.md`
 
 ### Removed
+
 - `PreferencesMenu.cs`


### PR DESCRIPTION
Fix for stale icon on splitable containers (such as pots for spaghetti).  

Markdown edits on based on linter suggestions.