### PR TITLE
Fix: resolve multiplayer sync freeze for 3+ players

### DIFF
--- a/CountUp.csproj
+++ b/CountUp.csproj
@@ -88,6 +88,9 @@
     <Reference Include="KitchenMods">
       <HintPath>$(PlateUpGameFolder)\PlateUp_Data\Managed\KitchenMods.dll</HintPath>
     </Reference>
+    <Reference Include="PlatformSettings">
+      <HintPath>$(PlateUpGameFolder)\PlateUp_Data\Managed\PlatformSettings.dll</HintPath>
+    </Reference>
     <Reference Include="MessagePack">
       <HintPath>$(PlateUpGameFolder)\PlateUp_Data\Managed\MessagePack.dll</HintPath>
     </Reference>

--- a/NetworkingUtils.cs
+++ b/NetworkingUtils.cs
@@ -1,5 +1,6 @@
 using Kitchen;
 using Kitchen.NetworkSupport;
+using Platforms;
 using System.Linq;
 
 namespace KitchenCountUp
@@ -8,22 +9,7 @@ namespace KitchenCountUp
     {
         public static bool IsHost()
         {
-            if (Session.NetworkPeers == null) return true;
-
-            bool isHost = Session.NetworkPeers.Count <= 1;
-            if (!isHost)
-            {
-                var peers = Session.NetworkPeers.ToArray();
-                foreach (var peer in peers)
-                {
-                    if (peer.Item2.Connection == ConnectionType.Local)
-                    {
-                        isHost = peer.Item1 == Session.HostIdentifier;
-                        break;
-                    }
-                }
-            }
-            return isHost;
+            return Session.NetworkedPlayState != NetworkedPlayState.Client;
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where new network logic prevented the update of player sync over 2 players due to a mishandled check.  The check for identifying the new host-client relationship only accounted for the check of a single host against a single client.  This caused the break above 2 players.